### PR TITLE
Feature/iamse 978

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ build
 *.iml
 .idea
 classes/
+/src/dist/bootstrap/plugin.properties
+/src/dist/webapp/WEB-INF/lib/*.jar

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,8 @@ repositories {
 }
 
 dependencies {
+    compileOnly "net.shibboleth.idp:idp-admin-api:${project.'shibboleth.version'}"
+    compileOnly "net.shibboleth.idp:idp-admin-impl:${project.'shibboleth.version'}"
     compileOnly "org.opensaml:opensaml-storage-api:${project.'opensaml.version'}"
     compileOnly "ch.qos.logback:logback-core:${project.'logback.version'}"
 

--- a/build.gradle
+++ b/build.gradle
@@ -4,10 +4,10 @@ plugins {
     id 'java'
     id 'idea'
     id 'distribution'
-    id 'com.jfrog.bintray' version '1.8.4'
+    id 'com.jfrog.bintray' version '1.8.4' // DONE
     id 'com.avast.gradle.docker-compose' version '0.8.0'
     id 'net.researchgate.release' version '2.7.0'
-    // id 'signing'
+    id 'signing'
 }
 
 apply from: 'gradle/shibboleth.gradle'
@@ -15,6 +15,7 @@ apply from: 'gradle/shibboleth.gradle'
 repositories {
     maven { url 'https://build.shibboleth.net/nexus/content/groups/public' }
     jcenter()
+    mavenCentral()
 }
 
 dependencies {
@@ -23,6 +24,7 @@ dependencies {
     compileOnly "org.opensaml:opensaml-storage-api:${project.'opensaml.version'}"
     compileOnly "ch.qos.logback:logback-core:${project.'logback.version'}"
 
+    implementation "commons-configuration:commons-configuration:${project.'commons-configuration.version'}"
     implementation "org.redisson:redisson:${project.'redisson.version'}", {
         exclude module: 'jackson-annotations'
         exclude module: 'jackson-core'
@@ -31,10 +33,71 @@ dependencies {
         exclude module: 'slf4j-api'
     }
 
-    testCompile "net.shibboleth.idp:idp-authn-api:${project.'shibboleth.version'}"
-    testCompile "org.opensaml:opensaml-storage-api:${project.'opensaml.version'}:tests@jar"
-    testCompile "junit:junit:4.12"
-    testCompile "org.testng:testng:6.9.9"
+    testImplementation "net.shibboleth.idp:idp-authn-api:${project.'shibboleth.version'}"
+    testImplementation "org.opensaml:opensaml-storage-api:${project.'opensaml.version'}:tests@jar"
+    testImplementation 'junit:junit:4.13.2'
+    testImplementation "org.testng:testng:7.4.0"
+    testImplementation "com.fasterxml.jackson.core:jackson-core:2.12.2"
+    testImplementation "com.fasterxml.jackson.core:jackson-databind:2.12.2"
+}
+
+processResources {
+    from ('src/main/java') {
+        include "**/*.properties"
+    }
+}
+
+clean {
+    delete (layout.projectDirectory.dir("src/dist/bootstrap/plugin.properties"))
+    delete fileTree(layout.projectDirectory.dir("src/dist/webapp/WEB-INF/lib")) {
+        include "**/*.jar"
+    }
+}
+
+jar {
+    manifest {
+        attributes "Name": "net/unicon/iam/shibboleth/storage/redis/plugin/",
+                   "Implementation-Vendor": "unicon.net",
+                   "Implementation-Version": "${project.version}",
+                   "Implementation-Title": "${project.name}"
+
+    }
+}
+
+jar.finalizedBy("buildPluginArtifacts")
+
+task buildPluginArtifacts(type: GradleBuild, dependsOn: ['clean', 'jar']) {
+    group 'Build'
+    description 'Build the deployable artifacts for the plugin'
+
+    copy {
+        from layout.projectDirectory.dir("src/main/java/net/unicon/iam/shibboleth/storage/redis/plugin/plugin.properties")
+        into layout.projectDirectory.dir("src/dist/bootstrap")
+    }
+    copy {
+        from layout.buildDirectory.dir("libs/${project.name}-${project.version}.jar")
+        into layout.projectDirectory.dir("src/dist/webapp/WEB-INF/lib")
+    }
+    copy {
+        from { project.configurations.runtimeClasspath }
+        into ('src/dist/webapp/WEB-INF/lib')
+    }
+    finalizedBy distTar {
+        archivesBaseName = "${project.name}"
+        archiveExtension = 'tar.gz'
+        compression = Compression.GZIP
+
+        from layout.projectDirectory.dir("src/dist/")
+        exclude "**/.gitkeep"
+        exclude "/${project.name}-${project.version}"
+        finalizedBy distZip {
+            archivesBaseName = "${project.name}"
+
+            from layout.projectDirectory.dir("src/dist/")
+            exclude "**/.gitkeep"
+            exclude "/${project.name}-${project.version}"
+        }
+    }
 }
 
 /*
@@ -51,23 +114,12 @@ dockerCompose {
 test {
     useTestNG()
     scanForTestClasses = false
-    include 'net/unicon/iam/shibboleth/**/*'
+    include 'net/unicon/iam/shibboleth/storage/redis/**/*'
     dependsOn 'composeUp'
     finalizedBy 'composeDown'
 }
 
-distributions {
-    main {
-        contents {
-            duplicatesStrategy = 'exclude'
-            into ('edit-webapp/WEB-INF/lib') {
-                from { project.jar }
-                from { project.configurations.runtimeClasspath }
-            }
-        }
-    }
-}
-
+/*
 bintray {
     user = bintrayUsername
     key = bintrayAPIKey
@@ -86,7 +138,6 @@ bintray {
 
 afterReleaseBuild.dependsOn bintrayUpload
 
-/*
 signing {
     sign configurations.archives
 }

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'java'
     id 'idea'
     id 'distribution'
-    id 'com.jfrog.bintray' version '1.8.4' // DONE
+    id 'com.jfrog.bintray' version '1.8.4' // NO LONGER AVAILABLE
     id 'com.avast.gradle.docker-compose' version '0.8.0'
     id 'net.researchgate.release' version '2.7.0'
     id 'signing'
@@ -35,10 +35,10 @@ dependencies {
 
     testImplementation "net.shibboleth.idp:idp-authn-api:${project.'shibboleth.version'}"
     testImplementation "org.opensaml:opensaml-storage-api:${project.'opensaml.version'}:tests@jar"
-    testImplementation 'junit:junit:4.13.2'
-    testImplementation "org.testng:testng:7.4.0"
-    testImplementation "com.fasterxml.jackson.core:jackson-core:2.12.2"
-    testImplementation "com.fasterxml.jackson.core:jackson-databind:2.12.2"
+    testImplementation "junit:junit:${project.'junit.version'}"
+    testImplementation "org.testng:testng:${project.'testng.version'}"
+    testImplementation "com.fasterxml.jackson.core:jackson-core:${project.'jackson.version'}"
+    testImplementation "com.fasterxml.jackson.core:jackson-databind:${project.'jackson.version'}"
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ gradle.version=5.3.1
 version=2.0.0-SNAPSHOT
 group=net.unicon.iam.shibboleth
 
-shibboleth.version=3.4.1
+shibboleth.version=4.1.4
 opensaml.version=3.4.0
 logback.version=1.1.2
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,6 @@
 gradle.version=5.3.1
 
 version=2.0.0-SNAPSHOT
-group=net.unicon.iam.shibboleth
 
 shibboleth.version=4.1.4
 opensaml.version=3.4.0
@@ -12,7 +11,6 @@ redisson.version=3.10.1
 # for shibboleth bootstrapping
 commons-configuration.version=1.10
 bouncycastle.version=1.56
-gradle-docker-plugin.version=3.0.4
 
 # If you are deploying to bintray, these should be set in your global `gradle.properties` file
 bintrayUsername=

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,16 +1,19 @@
 gradle.version=5.3.1
-
 version=2.0.0-SNAPSHOT
 
-shibboleth.version=4.1.4
-opensaml.version=3.4.0
+#Library versions
+jackson.version=2.12.2
+junit.version=4.13.2
 logback.version=1.1.2
-
+opensaml.version=3.4.0
 redisson.version=3.10.1
+shibboleth.version=4.1.4
+testng.version=7.4.0
 
 # for shibboleth bootstrapping
-commons-configuration.version=1.10
 bouncycastle.version=1.56
+commons-configuration.version=1.10
+shibboleth.utilities.java-support.version=8.2.1
 
 # If you are deploying to bintray, these should be set in your global `gradle.properties` file
 bintrayUsername=

--- a/gradle/shibboleth.gradle
+++ b/gradle/shibboleth.gradle
@@ -126,7 +126,7 @@ task generateSealerKey(dependsOn: 'processIdpProperties') {
 
 ant.taskdef(
         name: 'selfsignedcert',
-        classname: 'net.shibboleth.idp.installer.ant.SelfSignedCertificateGeneratorTask',
+        classname: 'net.shibboleth.idp.installer.ant.impl.SelfSignedCertificateGeneratorTask',
         classpath: configurations.shibbolethAntTasks.asPath
 )
 

--- a/gradle/shibboleth.gradle
+++ b/gradle/shibboleth.gradle
@@ -14,7 +14,6 @@ repositories {
     jcenter()
     maven {
         url 'https://build.shibboleth.net/nexus/content/groups/public'
-
     }
 }
 
@@ -29,7 +28,7 @@ dependencies {
 
     shibbolethAntTasks "net.shibboleth.idp:idp-installer:${project.'shibboleth.version'}"
     shibbolethAntTasks "org.bouncycastle:bcpkix-jdk15on:${project.'bouncycastle.version'}"
-    shibbolethAntTasks "net.shibboleth.utilities:java-support:8.2.1"
+    shibbolethAntTasks "net.shibboleth.utilities:java-support:${project.'shibboleth.utilities.java-support.version'}"
 
 }
 

--- a/gradle/shibboleth.gradle
+++ b/gradle/shibboleth.gradle
@@ -29,6 +29,8 @@ dependencies {
 
     shibbolethAntTasks "net.shibboleth.idp:idp-installer:${project.'shibboleth.version'}"
     shibbolethAntTasks "org.bouncycastle:bcpkix-jdk15on:${project.'bouncycastle.version'}"
+    shibbolethAntTasks "net.shibboleth.utilities:java-support:8.2.1"
+
 }
 
 task unpackShibboleth {
@@ -113,7 +115,7 @@ task generateSealerKey(dependsOn: 'processIdpProperties') {
     doLast {
         file("build/overlay/credentials").mkdirs()
         if (!(copyOverlayFile('credentials/sealer.jks') && copyOverlayFile('credentials/sealer.kver'))) {
-            ant.taskdef(name: 'sealer', classname: 'net.shibboleth.idp.installer.ant.BasicKeystoreKeyStrategyTask', classpath: configurations.shibbolethAntTasks.asPath)
+            ant.taskdef(name: 'sealer', classname: 'net.shibboleth.idp.installer.ant.impl.BasicKeystoreKeyStrategyTask', classpath: configurations.shibbolethAntTasks.asPath)
             ant.sealer(
                     keystoreFile: sealerKeystore,
                     versionFile: sealerKeyVersion,

--- a/plugin/plugin.gradle
+++ b/plugin/plugin.gradle
@@ -1,1 +1,0 @@
-// copy plugin.properties to the bootstrap dir for the build

--- a/plugin/plugin.gradle
+++ b/plugin/plugin.gradle
@@ -1,0 +1,1 @@
+// copy plugin.properties to the bootstrap dir for the build

--- a/src/main/java/net/unicon/iam/shibboleth/storage/plugin/RedisStorageServicePlugin.java
+++ b/src/main/java/net/unicon/iam/shibboleth/storage/plugin/RedisStorageServicePlugin.java
@@ -1,0 +1,13 @@
+package net.unicon.iam.shibboleth.storage.plugin;
+
+import net.shibboleth.idp.plugin.PluginException;
+import net.shibboleth.idp.plugin.PropertyDrivenIdPPlugin;
+
+import java.io.IOException;
+
+public class RedisStorageServicePlugin extends PropertyDrivenIdPPlugin {
+
+    public RedisStorageServicePlugin() throws PluginException, IOException {
+        super(RedisStorageServicePlugin.class);
+    }
+}

--- a/src/main/java/net/unicon/iam/shibboleth/storage/plugin/plugin.properties
+++ b/src/main/java/net/unicon/iam/shibboleth/storage/plugin/plugin.properties
@@ -1,2 +1,0 @@
-plugin.id = net.unicon.iam.shibboleth.storage.redis
-plugin.version = 1.0.0

--- a/src/main/java/net/unicon/iam/shibboleth/storage/plugin/plugin.properties
+++ b/src/main/java/net/unicon/iam/shibboleth/storage/plugin/plugin.properties
@@ -1,0 +1,2 @@
+plugin.id = net.unicon.iam.shibboleth.storage.redis
+plugin.version = 1.0.0

--- a/src/main/java/net/unicon/iam/shibboleth/storage/redis/RedisStorageService.java
+++ b/src/main/java/net/unicon/iam/shibboleth/storage/redis/RedisStorageService.java
@@ -1,4 +1,4 @@
-package net.unicon.iam.shibboleth.storage;
+package net.unicon.iam.shibboleth.storage.redis;
 
 
 import net.shibboleth.utilities.java.support.collection.Pair;

--- a/src/main/java/net/unicon/iam/shibboleth/storage/redis/VersionMutableStorageRecord.java
+++ b/src/main/java/net/unicon/iam/shibboleth/storage/redis/VersionMutableStorageRecord.java
@@ -1,4 +1,4 @@
-package net.unicon.iam.shibboleth.storage;
+package net.unicon.iam.shibboleth.storage.redis;
 
 import org.opensaml.storage.MutableStorageRecord;
 

--- a/src/main/java/net/unicon/iam/shibboleth/storage/redis/plugin/RedisStorageServicePlugin.java
+++ b/src/main/java/net/unicon/iam/shibboleth/storage/redis/plugin/RedisStorageServicePlugin.java
@@ -1,4 +1,4 @@
-package net.unicon.iam.shibboleth.storage.plugin;
+package net.unicon.iam.shibboleth.storage.redis.plugin;
 
 import net.shibboleth.idp.plugin.PluginException;
 import net.shibboleth.idp.plugin.PropertyDrivenIdPPlugin;

--- a/src/main/java/net/unicon/iam/shibboleth/storage/redis/plugin/plugin.properties
+++ b/src/main/java/net/unicon/iam/shibboleth/storage/redis/plugin/plugin.properties
@@ -1,0 +1,3 @@
+plugin.id = net.unicon.iam.shibboleth.storage.redis.plugin.RedisStorageServicePlugin
+plugin.version = 1.0.0
+plugin.url.0=https://github.com/UniconLabs/shibboleth-redis-storage-service/blob/master/update.properties

--- a/src/main/resources/META-INF/services/net.shibboleth.idp.plugin.IdPPlugin
+++ b/src/main/resources/META-INF/services/net.shibboleth.idp.plugin.IdPPlugin
@@ -1,1 +1,1 @@
-net.unicon.iam.shibboleth.storage.plugin.RedisStorageServicePlugin
+net.unicon.iam.shibboleth.storage.redis.plugin.RedisStorageServicePlugin

--- a/src/main/resources/META-INF/services/net.shibboleth.idp.plugin.IdPPlugin
+++ b/src/main/resources/META-INF/services/net.shibboleth.idp.plugin.IdPPlugin
@@ -1,0 +1,1 @@
+net.unicon.iam.shibboleth.storage.plugin.RedisStorageServicePlugin

--- a/src/test/java/net/unicon/iam/shibboleth/storage/redis/RedisStorageServiceTest.java
+++ b/src/test/java/net/unicon/iam/shibboleth/storage/redis/RedisStorageServiceTest.java
@@ -1,10 +1,9 @@
-package net.unicon.iam.shibboleth.storage;
-
+package net.unicon.iam.shibboleth.storage.redis;
 
 import net.shibboleth.utilities.java.support.component.ComponentInitializationException;
 import org.opensaml.storage.StorageRecord;
 import org.opensaml.storage.StorageService;
-import org.opensaml.storage.StorageServiceTest;
+import org.opensaml.storage.testing.StorageServiceTest;
 import org.redisson.Redisson;
 import org.redisson.config.Config;
 import org.testng.annotations.AfterClass;

--- a/update.properties
+++ b/update.properties
@@ -1,0 +1,6 @@
+# Information in this file is read by remote systems needing plugin status.
+# see: https://shibboleth.atlassian.net/wiki/spaces/IDP4/pages/1296760857/PluginDevelopment#Maintaining-the-Update-Property-File
+
+net.unicon.iam.shibboleth.storage.redis.plugin.RedisStorageServicePlugin.idpVersionMax.1.0.0=5.0.0
+net.unicon.iam.shibboleth.storage.redis.plugin.RedisStorageServicePlugin.idpVersionMin.1.0.0=4.1.0
+net.unicon.iam.shibboleth.storage.redis.plugin.RedisStorageServicePlugin.supportLevel.1.0.0 = Current


### PR DESCRIPTION
Project should now build artifacts according to the documentation at: https://shibboleth.atlassian.net/wiki/spaces/IDP4/pages/1296760857/PluginDevelopment

Need to discuss versioning of the plugin (the project version is at 2.0.0, though this is the first version of the plugin - not sure if we care or want separate versions of the plugin (1.0.0) which houses the 2.0.0 artifact.

Need to discuss the hosting. The build was using bintray which is not available. Unsure where the artifacts need to live. Additionally, the update.properties file is meant to live separately so that certain settings are flexible without having to create a new deployment artifact. I currently set the url for the update.properties file to the master branch location of the source in the uniconlabs project (this project). If we want to move the file to another public location then the url in a different file has to be updated (and probably there should be some automated process to handle keeping that in sync?)


**NOT DONE:**
The tar.gz and .zip files are not signed